### PR TITLE
Improve installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 sh install.sh
 ```
 
+note: perform `pip install pandas nvidia-ml-py scikit-learn` to install required libraries
+
 ## Usage
 ```
 python train.py

--- a/install.sh
+++ b/install.sh
@@ -2,5 +2,6 @@
 
 curl -O https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz \
  && tar xvzfo cifar-10-python.tar.gz \
+ && mkdir -p input \
  && mv cifar-10-batches-py input/ \
  && rm cifar-10-python.tar.gz


### PR DESCRIPTION
Without `input` directory, test data goes into wrong path.

Also, add a note about required libraries.
